### PR TITLE
feat: add must-revalidate directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ You can have a better overview of the percentage of success by looking your Clou
 - [Server rendered pages are not optional, by Guillermo Rauch](https://rauchg.com/2014/7-principles-of-rich-web-applications#server-rendered-pages-are-not-optional).
 - [Increasing the Performance of Dynamic Next.JS Websites, by scale AI](https://scale.ai/blog/performance-on-next-js-websites).
 - [The Benefits of Microcaching, by NGINX](https://www.nginx.com/blog/benefits-of-microcaching-nginx/).
+- [Cache-Control for Civilians, by Harry Robert](https://csswizardry.com/2019/03/cache-control-for-civilians/)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const createSetHeaders = ({ revalidate }) => {
 
     res.setHeader(
       'Cache-Control',
-      `public, max-age=${maxAge}, s-maxage=${maxAge}, stale-while-revalidate=${
+      `public, must-revalidate, max-age=${maxAge}, s-maxage=${maxAge}, stale-while-revalidate=${
         hasForce ? 0 : toSeconds(revalidate(ttl))
       }`
     )


### PR DESCRIPTION
After reading Harry's blog post about caching directive, adding "must-revalidate" allow us to avoid a network request if the content doesn't change.