### PR TITLE
Serve stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ This value can be specified as well providing it as part of [`.get`](#get) outpu
 
 If you don't provide one, this be used as fallback for avoid keep things into cache forever.
 
+##### serveStale
+
+Type: `number`<br/>
+Default: `0`
+
+Number of milliseconds after ttl has expired that we send the stale content. The get method will still be called, and the cache will be updated.
+
+Similar to `stale-while-revalidate,` this allows us to send a fast response while we freshen up the cache for the next visitor.
+
+The default value of `0` has no effect.
+
 ##### serialize
 
 Type: `function`<br/>

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ declare namespace CacheableResponse {
     get: (
       opts: Options
     ) => Promise<
-      (Optional<Cache<Data>, "etag" | "ttl" | "createdAt"> & GetReturnProps) | null
+      (Optional<Cache<Data>, "etag" | "ttl" | "serveStale" | "createdAt"> & GetReturnProps) | null
     >;
 
     /**
@@ -92,6 +92,7 @@ declare namespace CacheableResponse {
     createdAt: number;
     /** ttl in milliseconds */
     ttl: number;
+    serveStale: number;
     /** cached value */
     data: T;
   }

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = ({
     const {
       etag: cachedEtag,
       ttl = defaultTtl,
-      serveStale = ttl,
+      serveStale = 0,
       createdAt = Date.now(),
       data,
       ...props

--- a/index.js
+++ b/index.js
@@ -136,7 +136,8 @@ module.exports = ({
     }
 
     const sendResult = send({ data, res, req, ...props })
-    if (Date.now() - createdAt > ttl) {
+    const elapsedMillis = Date.now() - createdAt
+    if (elapsedMillis > ttl && elapsedMillis <= serveStale) {
       const {
         ttl = defaultTtl,
         serveStale = ttl,
@@ -145,7 +146,7 @@ module.exports = ({
         ...props
       } = await get(opts)
       const etag = getEtag(serialize(data))
-      setCache(compress, cache, key, {
+      await setCache(compress, cache, key, {
         etag,
         createdAt,
         ttl,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     {
       "name": "whooehoo",
       "email": "whooehoo@yandex.ru"
+    },
+    {
+      "name": "mattraibert",
+      "email": "mattraibert@positiondev.com"
     }
   ],
   "repository": {
@@ -99,6 +103,7 @@
     "release:github": "conventional-github-releaser -p angular",
     "release:tags": "git push --follow-tags origin HEAD:master",
     "test": "nyc ava",
+    "test:watch": "ava --watch --verbose",
     "update": "ncu -u",
     "update:check": "ncu -- --error-level 2"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -205,42 +205,72 @@ test('MISS after cache expiration', async t => {
   t.is(headers['x-cache-status'], 'MISS')
 })
 
-test('refreshEarly millis returns old cached, while refreshing', async t => {
-  const cacheMissTimestamps = []
-  const ttl = 60 * 1000
-  const refreshEarly = 100
+test('serveStale millis returns old cached content while refreshing', async t => {
+  const responseBodies = ['first', 'second']
+  const ttl = 1
+  const serveStale = 7200000
+  let cache = new Keyv({ namespace: 'test' })
   const url = await createServer({
+    cache,
     get: ({ req, res }) => {
       return {
         ttl,
-        refreshEarly,
-        createdAt: (() => {
-          const now = Date.now()
-          cacheMissTimestamps.push(now)
-          return now
-        })(),
-        data: Math.random()
+        serveStale,
+        createdAt: Date.now(),
+        data: responseBodies.shift()
       }
     },
     send: ({ data, headers, res, req, ...props }) => {
       res.end(`${data}`)
-    },
-    revalidate: 7200000
+    }
   })
-  // initial render populates the cache
-  const initialResponse = await got(`${url}/kikobeats`)
+  const initial = await got(`${url}/kikobeats`)
 
-  while (Date.now() - cacheMissTimestamps[0] < refreshEarly) {}
-  const hitWhileRefreshing = await got(`${url}/kikobeats`)
-  t.is(hitWhileRefreshing.headers['x-cache-status'], 'HIT')
-  t.is(hitWhileRefreshing.headers['x-cache-expired-at'], '59.8s')
-  t.is(initialResponse.body, hitWhileRefreshing.body)
+  t.is(initial.body, 'first')
+  t.is(initial.headers['x-cache-status'], 'MISS')
 
-  t.is(cacheMissTimestamps.length, 2)
-  const hitAfterRefresh = await got(`${url}/kikobeats`)
-  t.is(hitAfterRefresh.headers['x-cache-status'], 'HIT')
-  t.is(hitAfterRefresh.headers['x-cache-expired-at'], '59.9s')
-  t.not(initialResponse.body, hitAfterRefresh.body)
+  const staleAfterTtl = await got(`${url}/kikobeats`)
+
+  t.is(staleAfterTtl.body, 'first')
+  t.is(staleAfterTtl.headers['x-cache-status'], 'HIT')
+
+  t.is((await cache.get('/kikobeats')).data, 'second')
+})
+
+test('sends fresh content on the first request after refresh', async t => {
+  const responseBodies = ['first', 'second', 'third']
+  const ttl = 1
+  const serveStale = 7200000
+  let cache = new Keyv({ namespace: 'test' })
+  const url = await createServer({
+    cache,
+    get: ({ req, res }) => {
+      return {
+        ttl,
+        serveStale,
+        data: responseBodies.shift()
+      }
+    },
+    send: ({ data, headers, res, req, ...props }) => {
+      res.end(`${data}`)
+    }
+  })
+  const initial = await got(`${url}/kikobeats`)
+
+  t.is(initial.body, 'first')
+  t.is(initial.headers['x-cache-status'], 'MISS')
+
+  const staleAfterTtl = await got(`${url}/kikobeats`)
+
+  t.is(staleAfterTtl.body, 'first')
+  t.is(staleAfterTtl.headers['x-cache-status'], 'HIT')
+
+  t.is((await cache.get('/kikobeats')).data, 'second')
+
+  const afterRefresh = await got(`${url}/kikobeats`)
+
+  t.is(afterRefresh.body, 'second')
+  t.is(afterRefresh.headers['x-cache-status'], 'HIT')
 })
 
 test('etag is present', async t => {


### PR DESCRIPTION
This is a feature that I wanted because of spotty support of `stale-while-revalidate`.

If `get` returns `serveStale` then we should hang on to the content and serve it while the cache is being updated with new content.

This is kind of inspired by this blog post that you linked:
https://www.nginx.com/blog/benefits-of-microcaching-nginx/

Would you be interested in merging something like this into this library?