### PR TITLE
fix: typescript definition wrongly defines a non existing property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ declare namespace CacheableResponse {
     compress?: boolean;
 
     /** Get cache key from request context */
-    getKey?: (opts: Options) => string;
+    key?: (opts: Options) => string;
 
     /**
      * Number of milliseconds that indicates grace period after response cache expiration for refreshing it in the background.


### PR DESCRIPTION
in the typescript definition, the [`key`](https://github.com/Kikobeats/cacheable-response#key) property is wrongly defined as `getKey` instead of `key`. 

**Additional Info:**

this change was done in https://github.com/Kikobeats/cacheable-response/blob/e133b3fa9018d725099c6a4587b7ab43ef0b3902/CHANGELOG.md#260-2021-08-19 

and is a BREAKING CHANGE and should therefore have bumped the major version.

I strongly suggest to adopt semantic versioning to avoid problems like that