### PR TITLE
fix: force bypass returns fresh data during stale window

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@keyvhq/core": "~2.1.0",
-    "@keyvhq/memoize": "~2.2.1",
+    "@keyvhq/memoize": "~2.2.4",
     "compress-brotli": "~1.3.9",
     "etag": "~1.8.1"
   },

--- a/test/status.js
+++ b/test/status.js
@@ -66,6 +66,33 @@ test('EXPIRED after cache expiration', async t => {
   t.is((await doRequest()).headers['x-cache-status'], 'EXPIRED')
 })
 
+test('BYPASS for forcing refresh when response is stale', async t => {
+  let index = 0
+  const url = await runServer(
+    t,
+    cacheableResponse({
+      staleTtl: 80,
+      ttl: 100,
+      get: ({ req, res }) => {
+        return {
+          data: { value: ++index },
+          createdAt: Date.now()
+        }
+      },
+      send: ({ data, headers, res, req, ...props }) => {
+        res.end(data.value.toString())
+      }
+    })
+  )
+  t.is((await got(`${url}/kikobeats`)).body, '1')
+  await setTimeout(25)
+  t.is((await got(`${url}/kikobeats`)).headers['x-cache-status'], 'STALE')
+  const { body, headers } = await got(`${url}/kikobeats?force=true`)
+  t.is(headers['x-cache-status'], 'BYPASS')
+  t.not(body, '1')
+  t.is(body, String(index))
+})
+
 test('BYPASS for forcing refresh', async t => {
   let index = 0
   const url = await runServer(


### PR DESCRIPTION
## Summary

- Bump `@keyvhq/memoize` from `~2.2.1` to `~2.2.4` which fixes the stale-while-revalidate fast-path ignoring `forceExpiration`
- Add regression test: `BYPASS for forcing refresh when response is stale`

## Context

When `?force=true` was used while a cached entry was in the stale window, the response body was stale data even though `X-Cache-Status` reported `BYPASS`. Fixed upstream in `@keyvhq/memoize@2.2.4`.

Supersedes #130 and #131 (which vendored the dependency instead).

## Test plan

- [x] All 26 tests pass
- [x] New test confirms force bypass returns fresh data during SWR window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch plus a test; no application source changes beyond the memoize version.
> 
> **Overview**
> Fixes a bug where **`?force=true`** (or the configured bypass query param) could report **`X-Cache-Status: BYPASS`** while still returning **stale response body** during the stale-while-revalidate window.
> 
> The fix is delivered by bumping **`@keyvhq/memoize`** from `~2.2.1` to **`~2.2.4`**, which corrects the memoize fast-path ignoring **`forceExpiration`** when an entry is stale. A new integration test in **`test/status.js`** locks in the behavior: after entering **STALE**, a forced request must **BYPASS** and return freshly generated data, not the original cached value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eaf4e90267d516468f3f619a851ad048832a9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->