### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "ssr"
   ],
   "dependencies": {
-    "@keyvhq/core": "~2.1.0",
-    "@keyvhq/memoize": "~2.2.4",
-    "compress-brotli": "~1.3.9",
+    "@keyvhq/core": "~2.1.15",
+    "@keyvhq/memoize": "~2.2.5",
+    "compress-brotli": "~1.3.14",
     "etag": "~1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only patch updates with no code changes; risk is limited to upstream behavior in caching and brotli compression used by the library.
> 
> **Overview**
> Bumps three runtime dependencies in `package.json` to newer patch releases within existing semver ranges: `@keyvhq/core` (~2.1.0 → ~2.1.15), `@keyvhq/memoize` (~2.2.4 → ~2.2.5), and `compress-brotli` (~1.3.9 → ~1.3.14). No application source or test code changes—only the declared dependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caec31d740be3d741d51fb44fda34c4f789b573d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->